### PR TITLE
Uplift PyGithub

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-PyGithub==1.46
+PyGithub==1.50
 fabric==2.5.0
 pytz==2019.3


### PR DESCRIPTION
This uplift is needed because it includes https://github.com/PyGithub/PyGithub/pull/1451, which fixes a bug which prevented issues from being moved between columns on the project board.